### PR TITLE
Updated to RISC-V DV commit '39797b2f07784e775149a4f05c90fee2427124e5'

### DIFF
--- a/scripts/core_integrate.sh
+++ b/scripts/core_integrate.sh
@@ -5,7 +5,7 @@ BASE_DIR=$(cd ${SCRIPT_PATH}; cd ..; pwd)
 echo "BASE_DIR = ${BASE_DIR}"
 
 RV_DV_REMOTE='https://github.com/google/riscv-dv.git'
-RV_DV_COMMIT_SHA='0c640e3a9eb37a9d28b7f21104d0024b7148d7cf'
+RV_DV_COMMIT_SHA='39797b2f07784e775149a4f05c90fee2427124e5'
 
 SWERV_REMOTE='https://github.com/chipsalliance/Cores-SweRV.git'
 SWERV_COMMIT_SHA='7332edc0adaa7e9a0c842d169154429e8d987786'


### PR DESCRIPTION
a) A lot of changes in `pygen_src` files to add `rv32m` and `rv32c`
but it's still a work in process
b) `rv32B` pseudo instructions added in `lib.py`
c) Minor changes in `ovpsim_log_to_trace` and `spike_log_to_trace`
d) Pandas added in python package requirements
e) And some very minor changes