### PR TITLE
Updated to RISCV-DV latest commit

### DIFF
--- a/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/cmark.ld
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/cmark.ld
@@ -1,0 +1,13 @@
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .text   : { *(.text*) }
+ _end = .;
+  . = 0xf0040000;
+  .data  :  { *(.*data) *(.rodata*) *(.sbss) STACK = ALIGN(16) + 0x1000;}
+  .bss : { *(.bss) }
+  . = 0xfffffff8;
+  .data.ctl : { LONG(0xf0040000); LONG(STACK) }
+}

--- a/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/cmark_dccm.ld
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/cmark_dccm.ld
@@ -1,0 +1,13 @@
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .text   : { *(.text*) }
+ _end = .;
+  . = 0xf0040000;
+  .data  :  { *(.*data) *(.rodata*) *(.sbss) STACK = ALIGN(16) + 0x1000;}
+  .bss : { *(.bss) }
+  . = 0xfffffff8;
+  .data.ctl : { LONG(0xf0040000); LONG(STACK) }
+}

--- a/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/cmark_iccm.ld
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/cmark_iccm.ld
@@ -1,0 +1,19 @@
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+MEMORY {
+    EXTCODE : ORIGIN = 0,          LENGTH = 0x10000
+    EXTDATA : ORIGIN = 0x10000,    LENGTH = 0x10000
+    ICCM    : ORIGIN = 0xee000000, LENGTH = 0x80000
+    DCCM    : ORIGIN = 0xf0040000, LENGTH = 0x10000
+    CTL     : ORIGIN = 0xfffffff0, LENGTH = 16
+}
+SECTIONS {
+  .text_init : {*(.text_init)} > EXTCODE
+  init_end = .;
+  .text : { *(.text) *(.text.startup)} > ICCM
+   text_end = .;
+  .data  :  { *(.*data) *(.rodata*) *(.sbss) STACK = ALIGN(16) + 0x1000;} > DCCM
+  .bss : { *(.bss)} > DCCM
+  .data.ctl :  { LONG(ADDR(.text)); LONG(text_end); LONG(0xf0040000); LONG(STACK)}>CTL
+}

--- a/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/hello_world_dccm.ld
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/hello_world_dccm.ld
@@ -1,0 +1,13 @@
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .text   : { *(.text*) }
+ _end = .;
+  . = 0xf0040000;
+  .data  :  { *(.*data) *(.rodata*) *(.sbss) STACK = ALIGN(16) + 0x1000;}
+  .bss : { *(.bss) }
+  . = 0xfffffff8;
+  .data.ctl : { LONG(0xf0040000); LONG(STACK) }
+}

--- a/scripts/core_integrate.sh
+++ b/scripts/core_integrate.sh
@@ -21,7 +21,7 @@ BASE_DIR=$(cd ${SCRIPT_PATH}; cd ..; pwd)
 echo "BASE_DIR = ${BASE_DIR}"
 
 RV_DV_REMOTE='https://github.com/google/riscv-dv.git'
-RV_DV_COMMIT_SHA='cff4f2558006dc3a292c250d6bf0d744d4eff0bd'
+RV_DV_COMMIT_SHA='3cdce00e63997201d0f00294365d920ff5e3ba7d'
 
 SWERV_REMOTE='https://github.com/chipsalliance/Cores-SweRV.git'
 SWERV_COMMIT_SHA='7332edc0adaa7e9a0c842d169154429e8d987786'


### PR DESCRIPTION
Commit ID: "3cdce00e63997201d0f00294365d920ff5e3ba7d"
Major changes:
a) Added the conversion of all the string comparison of riscv_core_setting fields to a python enum type.
b) Added linker files for directed tests in integration files according to mkefile path.