### PR TITLE
Updated custom linker file option in lm_run.py and makefile for TEST=…

### DIFF
--- a/integration_files/SweRV_EH1/Makefile
+++ b/integration_files/SweRV_EH1/Makefile
@@ -63,12 +63,7 @@ SIGNATURE_ADDR      := 0xd0580000
 # else use linker file from google's riscv-dv (scripts/link.ld)
 LINK				:= 1
 # provide specific link file
-ifeq (,$(wildcard riscv_dv_extension/linker_scripts/$(TEST).ld))
-	# path to custom linker file
-	LINK_FILE	= riscv_dv_extension/link.ld 
-else
-	LINK_FILE = riscv_dv_extension/linker_scripts/$(TEST).ld
-endif
+LINK_FILE	= riscv_dv_extension/link.ld
 # User Extension Directory for GCC Compilation
 GCC_USER_EXT_PATH	:= $(realpath snapshots/default)
 

--- a/integration_files/SweRV_EH1/riscv_dv_extension/testlist.yaml
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/testlist.yaml
@@ -1,4 +1,4 @@
- sc# Copyright Google LLC
+# Copyright Google LLC
 # Copyright 2020 Lampro Mellon
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration_files/SweRV_EH1/riscv_dv_extension/testlist.yaml
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/testlist.yaml
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+ sc# Copyright Google LLC
 # Copyright 2020 Lampro Mellon
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration_files/SweRV_EH1/riscv_dv_extension/testlist.yaml
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/testlist.yaml
@@ -37,29 +37,39 @@
   gcc_opts: -g -O3 -funroll-all-loops
   iterations: 1
   rtl_test: core_base_test_benchmark
+  no_iss: 1
+  no_post_compare: 1
 
 - test: cmark_iccm
   c_tests: directed_tests/c/cmark_iccm.c
   gcc_opts: -g -O3 -funroll-all-loops
   iterations: 1
   rtl_test: core_base_test_benchmark
-
+  no_iss: 1
+  no_post_compare: 1
+  
 - test: c_sample
   c_tests: directed_tests/c/c_sample.c
   gcc_opts: -g -O3 -funroll-all-loops
   iterations: 1
   rtl_test: core_base_test_benchmark
+  no_iss: 1
+  no_post_compare: 1
 
 - test: hello_world
   asm_tests: directed_tests/asm/hello_world.s
   iterations: 1
   rtl_test: core_base_test_benchmark
+  no_iss: 1
+  no_post_compare: 1
 
 - test: hello_world_dccm
   asm_tests: directed_tests/asm/hello_world_dccm.s
   iterations: 1
   rtl_test: core_base_test_benchmark
-
+  no_iss: 1
+  no_post_compare: 1
+  
 - test: riscv_arithmetic_basic_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions


### PR DESCRIPTION
…all command.
**Issue** : While running all the tests (directed and random both) simultaneously with TEST=all in the command , certain tests failed due to linker files issue.
**Resolved** : For  each test now it checks if there's custom linker file for that test then it uses that linker file otherwise the default one. This has been added in the lm_run.py.