### PR TITLE
riscv-compliance tests as directed tests

### DIFF
--- a/integration_files/SweRV_EH1/google_riscv_dv/lm_run.py
+++ b/integration_files/SweRV_EH1/google_riscv_dv/lm_run.py
@@ -477,7 +477,8 @@ def run_assembly(asm_test, iss_yaml, isa, mabi, gcc_opts, iss_opts, output_dir,
   run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
   
   # Generating disassembly dump
-  cmd = ('%s --disassemble-all --disassemble-zeroes -M no-aliases --section=.text --section=.data %s > %s' % (get_env_var("RISCV_OBJDUMP", debug_cmd = debug_cmd), elf, dump))
+  #cmd = ('%s --disassemble-all --disassemble-zeroes -M no-aliases --section=.text --section=.data %s > %s' % (get_env_var("RISCV_OBJDUMP", debug_cmd = debug_cmd), elf, dump))
+  cmd = ('%s --disassemble-all --disassemble-zeroes -M no-aliases %s > %s' % (get_env_var("RISCV_OBJDUMP", debug_cmd = debug_cmd), elf, dump))
   os.system(cmd)
     
   # Generating Program.hex

--- a/integration_files/SweRV_EH1/riscv-target/model_test.h
+++ b/integration_files/SweRV_EH1/riscv-target/model_test.h
@@ -1,0 +1,89 @@
+// RISC-V Compliance Test Header File
+// Copyright (c) 2017, Codasip Ltd. All Rights Reserved.
+// See LICENSE for license details.
+//
+// Description: Common header file for RV32I tests
+
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+
+//-----------------------------------------------------------------------
+// RV Compliance Macros
+//-----------------------------------------------------------------------
+
+#define RVMODEL_HALT              \
+        la a0, data_begin;			\
+        la a1, data_end; \
+        li a2, 0x80005008;			\
+compliance_halt_loop: \
+        beq a0, a1, compliance_halt_break; \
+        addi a3, a0, 4; \
+compliance_halt_loop2: \
+        addi a3, a3, -1; \
+	\
+        lb a4, 0 (a3); \
+        srai a5, a4, 4; \
+        andi a5, a5, 0xF; \
+        li a6, 10; \
+        blt a5, a6, notLetter; \
+        addi a5, a5, 39; \
+notLetter: \
+        addi a5, a5, 0x30; \
+        sb a5, 0 (a2); \
+	\
+        srai a5, a4, 0; \
+        andi a5, a5, 0xF; \
+        li a6, 10; \
+        blt a5, a6, notLetter2; \
+        addi a5, a5, 39; \
+notLetter2: \
+        addi a5, a5, 0x30; \
+        sb a5, 0 (a2); \
+        bne a0, a3,compliance_halt_loop2;  \
+        addi a0, a0, 4; \
+	\
+        li a4, '\n'; \
+        sb a4, 0 (a2); \
+        j compliance_halt_loop; \
+  j compliance_halt_break;		\
+compliance_halt_break: \
+	li	a0,0x80005009;	\
+	sb	a3,0(a0);       \
+test_done:\
+        li      gp,1;   \
+        ecall;
+
+#define RVMODEL_BOOT                                            \
+        .section .text.init;                                            \
+        .align  4;                                                      \
+        .globl _start;                                                  \
+_start:                                                                 \
+
+#define RVMODEL_DATA_BEGIN .align 4; .global data_begin; data_begin:
+
+#define RVMODEL_DATA_END .align 4; .global data_end; data_end:
+// Env Variable to be set accordingly
+#define XLEN 32
+
+#define RVMODEL_IO_WRITE_STR(_SP, _STR)
+
+#define RVMODEL_IO_ASSERT_GPR_EQ(_SP, _R, _I)
+
+//RVTEST_IO_ASSERT_SFPR_EQ
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+//RVTEST_IO_ASSERT_DFPR_EQ
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+// TODO: specify the routine for setting machine software interrupt
+#define RVMODEL_SET_MSW_INT
+
+// TODO: specify the routine for clearing machine software interrupt
+#define RVMODEL_CLEAR_MSW_INT
+
+// TODO: specify the routine for clearing machine timer interrupt
+#define RVMODEL_CLEAR_MTIMER_INT
+
+// TODO: specify the routine for clearing machine external interrupt
+#define RVMODEL_CLEAR_MEXT_INT
+
+#endif // _COMPLIANCE_MODEL_H

--- a/integration_files/SweRV_EH1/riscv-target/testlists/testlist_C.yaml
+++ b/integration_files/SweRV_EH1/riscv-target/testlists/testlist_C.yaml
@@ -1,0 +1,168 @@
+# Copyright Google LLC
+# Copyright 2020 Lampro Mellon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# c_tests         : Path to directed, hand-coded C test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+- test: cadd-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cadd-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: caddi-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/caddi-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: caddi4spn-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/caddi4spn-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: caddi16sp-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/caddi16sp-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cand-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cand-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: candi-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/candi-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cbeqz-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cbeqz-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cbnez-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cbnez-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+# - test: cebreak-01
+#   asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cebreak-01.S
+#   iterations: 1
+#   rtl_test: core_compliance_test
+
+- test: cj-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cj-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cjal-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cjal-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cjalr-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cjalr-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cjr-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cjr-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cli-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cli-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: clui-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/clui-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: clw-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/clw-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: clwsp-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/clwsp-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cmv-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cmv-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cnop-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cnop-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cor-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cor-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cslli-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cslli-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: csrai-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/csrai-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: csrli-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/csrli-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: csub-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/csub-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: csw-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/csw-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cswsp-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cswsp-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: cxor-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/C/src/cxor-01.S
+  iterations: 1
+  rtl_test: core_compliance_test

--- a/integration_files/SweRV_EH1/riscv-target/testlists/testlist_I.yaml
+++ b/integration_files/SweRV_EH1/riscv-target/testlists/testlist_I.yaml
@@ -1,0 +1,225 @@
+# Copyright Google LLC
+# Copyright 2020 Lampro Mellon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# c_tests         : Path to directed, hand-coded C test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+- test: add-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/add-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: addi-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/addi-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: and-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/and-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+  
+- test: andi-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/andi-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: auipc-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/auipc-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: beq-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/beq-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: bge-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/bge-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: bgeu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/bgeu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: blt-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/blt-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: bltu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/bltu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: bne-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/bne-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: fence-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/fence-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+# - test: jal-01
+#   asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/jal-01.S
+#   iterations: 1
+#   rtl_test: core_compliance_test
+
+- test: jalr-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/jalr-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: lb-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/lb-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: lbu-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/lbu-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: lh-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/lh-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: lhu-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/lhu-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: lui-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/lui-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+ 
+- test: lw-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/lw-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: or-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/or-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: ori-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/ori-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sb-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sb-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sh-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sh-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sll-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sll-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: slli-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/slli-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: slt-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/slt-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: slti-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/slti-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sltiu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sltiu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sltu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sltu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sra-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sra-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: srai-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/srai-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: srl-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/srl-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: srli-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/srli-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sub-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sub-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: sw-align-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/sw-align-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: xor-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/xor-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: xori-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/xori-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+ 
+ 

--- a/integration_files/SweRV_EH1/riscv-target/testlists/testlist_I.yaml
+++ b/integration_files/SweRV_EH1/riscv-target/testlists/testlist_I.yaml
@@ -92,10 +92,10 @@
   iterations: 1
   rtl_test: core_compliance_test
 
-# - test: jal-01
-#   asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/jal-01.S
-#   iterations: 1
-#   rtl_test: core_compliance_test
+- test: jal-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/jal-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
 
 - test: jalr-01
   asm_tests: directed_tests/riscv-test-suite/rv32i_m/I/src/jalr-01.S

--- a/integration_files/SweRV_EH1/riscv-target/testlists/testlist_M.yaml
+++ b/integration_files/SweRV_EH1/riscv-target/testlists/testlist_M.yaml
@@ -1,0 +1,73 @@
+# Copyright Google LLC
+# Copyright 2020 Lampro Mellon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# c_tests         : Path to directed, hand-coded C test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+- test: div-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/div-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: divu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/divu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: mul-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/mul-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: mulh-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/mulh-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: mulhsu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/mulhsu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: mulhu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: rem-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/rem-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: remu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/M/src/remu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test

--- a/integration_files/SweRV_EH1/riscv-target/testlists/testlist_Zifencei.yaml
+++ b/integration_files/SweRV_EH1/riscv-target/testlists/testlist_Zifencei.yaml
@@ -1,0 +1,38 @@
+# Copyright Google LLC
+# Copyright 2020 Lampro Mellon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# c_tests         : Path to directed, hand-coded C test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+- test: Fencei
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/Zifencei/src/Fencei.S
+  iterations: 1
+  rtl_test: core_compliance_test

--- a/integration_files/SweRV_EH1/riscv-target/testlists/testlist_privilege.yaml
+++ b/integration_files/SweRV_EH1/riscv-target/testlists/testlist_privilege.yaml
@@ -1,0 +1,113 @@
+# Copyright Google LLC
+# Copyright 2020 Lampro Mellon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# c_tests         : Path to directed, hand-coded C test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+- test: ebreak
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/ebreak.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: ecall
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/ecall.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-beq-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-beq-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-bge-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-bge-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-bgeu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-bgeu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-blt-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-blt-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-bltu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-bltu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-bne-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-bne-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-jal-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-jal-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-lh-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-lh-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-lhu-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-lhu-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-lw-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-lw-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-sh-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-sh-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign-sw-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign-sw-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign1-jalr-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign1-jalr-01.S
+  iterations: 1
+  rtl_test: core_compliance_test
+
+- test: misalign2-jalr-01
+  asm_tests: directed_tests/riscv-test-suite/rv32i_m/privilege/src/misalign2-jalr-01.S
+  iterations: 1
+  rtl_test: core_compliance_test

--- a/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/link_comp.ld
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/link_comp.ld
@@ -1,0 +1,20 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  /*  . = 0x80000;*/
+  . = 0x80030000;
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}
+

--- a/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/link_comp.ld
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/linker_scripts/link_comp.ld
@@ -11,7 +11,7 @@ SECTIONS
   .text : { *(.text) }
   . = ALIGN(0x1000);
   /*  . = 0x80000;*/
-  . = 0x80030000;
+  . = 0x800e0000;
   .data : { *(.data) }
   .data.string : { *(.data.string)}
   .bss : { *(.bss) }

--- a/scripts/core_integrate.sh
+++ b/scripts/core_integrate.sh
@@ -26,12 +26,16 @@ RV_DV_COMMIT_SHA='0b625258549e733082c12e5dc749f05aefb07d5a'
 SWERV_REMOTE='https://github.com/chipsalliance/Cores-SweRV.git'
 SWERV_COMMIT_SHA='7332edc0adaa7e9a0c842d169154429e8d987786'
 
+RC_REMOTE='https://github.com/riscv/riscv-compliance.git'
+RC_COMMIT_SHA='0e77784916ed9c07842883ba6c62db2555a8335f'
+
 CORES="${BASE_DIR}/cores"
 INTEGRATED_CORES="${BASE_DIR}/integrated_cores"
 INTEGRATION_FILES="${BASE_DIR}/integration_files"
 RV_DV="${BASE_DIR}/google_riscv_dv"
 
 SWERV_LOCAL="${CORES}/SweRV_EH1"
+RC_LOCAL="${BASE_DIR}/riscv-compliance"
 
 
 # Clone RISCV-DV if it does not exist
@@ -78,6 +82,27 @@ else
     printf "HEAD of ${SWERV_LOCAL} is already at ${SWERV_COMMIT_SHA}! \n\n"
 fi
 
+# # Clone riscv-compliance if it does not exist
+printf "Checking for SweRV EH-1 with COMMIT ID: ${RC_COMMIT_SHA} ...\n\n"
+if [ -d "${RC_LOCAL}" ] && [ -d "${RC_LOCAL}/.git" ]
+then
+    printf "${RC_LOCAL}/ is already a git repository \n"
+    cd ${RC_LOCAL}
+    RC_SHA_OUTPUT=$(git log -1 --pretty=format:"%H")
+else
+    printf "${RC_LOCAL}/ is not a git repository \n"
+    RC_SHA_OUTPUT="-1"
+fi
+
+if [ ${RC_SHA_OUTPUT} != ${RC_COMMIT_SHA} ]
+then 
+    git clone ${RC_REMOTE} ${RC_LOCAL};
+    cd ${RC_LOCAL};
+    git checkout ${RC_COMMIT_SHA};
+else
+    printf "HEAD of ${RC_LOCAL} is already at ${RC_COMMIT_SHA}! \n\n"
+fi
+
 # Environment Setup for SweRV EH-1
 printf "Setting up the Environment for SweRV EH-1 core in integrated_cores/SweRV_EH1 ...\n";
 
@@ -101,3 +126,11 @@ cp "${INTEGRATION_FILES}/SweRV_EH1/google_riscv_dv/src/riscv_asm_program_gen.sv"
 cp "${INTEGRATION_FILES}/SweRV_EH1/google_riscv_dv/scripts/gen_csr_test.py" "${RV_DV}/scripts/";
 #cp "${INTEGRATION_FILES}/SweRV_EH1/google_riscv_dv/scripts/spike_log_to_trace_csv.py" "${RV_DV}/scripts/";
 cp "${INTEGRATION_FILES}/SweRV_EH1/google_riscv_dv/scripts/instr_trace_compare.py" "${RV_DV}/scripts/";
+
+# Setup SweRV-EH1 with riscv-compliance files
+cp -r "${RC_LOCAL}/riscv-test-suite" "${INTEGRATED_CORES}/SweRV_EH1/directed_tests/";
+cp -r "${RC_LOCAL}/riscv-test-env" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
+cp "${RC_LOCAL}/riscv-test-env/arch_test.h" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
+cp "${RC_LOCAL}/riscv-test-env/encoding.h" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
+cp -r "${INTEGRATION_FILES}/SweRV_EH1/riscv-target/model_test.h" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
+cp -r "${INTEGRATION_FILES}/SweRV_EH1/riscv-target/testlists/" "${INTEGRATED_CORES}/SweRV_EH1/riscv_dv_extension/";

--- a/scripts/core_integrate.sh
+++ b/scripts/core_integrate.sh
@@ -133,4 +133,3 @@ cp -r "${RC_LOCAL}/riscv-test-env" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/defa
 cp "${RC_LOCAL}/riscv-test-env/arch_test.h" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
 cp "${RC_LOCAL}/riscv-test-env/encoding.h" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
 cp -r "${INTEGRATION_FILES}/SweRV_EH1/riscv-target/model_test.h" "${INTEGRATED_CORES}/SweRV_EH1/snapshots/default/";
-cp -r "${INTEGRATION_FILES}/SweRV_EH1/riscv-target/testlists/" "${INTEGRATED_CORES}/SweRV_EH1/riscv_dv_extension/";


### PR DESCRIPTION
Have added riscv-compliance tests as directed tests in LM-RISCV-DV flow.
To run the test, use this pattern of command
make SEED=1001 TESTLIST=<path_to_testlist_I.yaml> TEST=add-01 WAVES=0 LINK_FILE=<path_to_link_comp.ld>